### PR TITLE
Add Fruit Jam example. use a timeout for USB host MIDI read.

### DIFF
--- a/examples/usb_host_midi_simpletest_fruitjam.py
+++ b/examples/usb_host_midi_simpletest_fruitjam.py
@@ -1,18 +1,21 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023 Scott Shawcroft for Adafruit Industries
+# SPDX-FileCopyrightText: Copyright (c) 2025 Tim Cocks for Adafruit Industries
 #
-# SPDX-License-Identifier: Unlicense
+# SPDX-License-Identifier: MIT
 
 import adafruit_midi
+import adafruit_tlv320
 import audiobusio
 import board
 import synthio
 import usb.core
-import wm8960
 from adafruit_midi.note_off import NoteOff
 from adafruit_midi.note_on import NoteOn
+from displayio import release_displays
+from pwmio import PWMOut
 
 import adafruit_usb_host_midi
 
+release_displays()
 print("Looking for midi device")
 raw_midi = None
 while raw_midi is None:
@@ -24,12 +27,20 @@ while raw_midi is None:
             continue
 
 
-# This setup is for the headphone output on the iMX RT 1060 EVK.
-dac = wm8960.WM8960(board.I2C())
-dac.start_i2s_out()
-audio = audiobusio.I2SOut(
-    board.AUDIO_BCLK, board.AUDIO_SYNC, board.AUDIO_TXD, main_clock=board.AUDIO_MCLK
-)
+mclk_pwm = PWMOut(board.I2S_MCLK, frequency=15_000_000, duty_cycle=2**15)
+
+i2c = board.I2C()
+dac = adafruit_tlv320.TLV320DAC3100(i2c)
+
+# set sample rate & bit depth, use bclk
+dac.configure_clocks(sample_rate=44100, bit_depth=16, mclk_freq=15_000_000)
+
+# use headphones
+dac.headphone_output = True
+dac.dac_volume = -5  # dB
+dac.headphone_volume = -30
+audio = audiobusio.I2SOut(board.I2S_BCLK, board.I2S_WS, board.I2S_DIN)
+
 synth = synthio.Synthesizer(sample_rate=44100)
 audio.play(synth)
 

--- a/examples/usb_host_midi_simpletest_rp2040usbfeather.py
+++ b/examples/usb_host_midi_simpletest_rp2040usbfeather.py
@@ -19,7 +19,7 @@ raw_midi = None
 while raw_midi is None:
     for device in usb.core.find(find_all=True):
         try:
-            raw_midi = adafruit_usb_host_midi.MIDI(device)
+            raw_midi = adafruit_usb_host_midi.MIDI(device, timeout=0.01)
             print("Found", hex(device.idVendor), hex(device.idProduct))
         except ValueError:
             continue


### PR DESCRIPTION
Set `timeout=0.01`  on the raw_midi USB Host init. That way reading will not block if there is no new data, which allows existing data in the input buffer to get processed in a more timely manner.

Resolves: https://github.com/adafruit/Adafruit_CircuitPython_MIDI/issues/63

Also added a new Fruit Jam example that is largely the same as existing simpletest but adapted for the TLV320 dac onboard.